### PR TITLE
fix invalid timestamp format

### DIFF
--- a/lib/ar.js
+++ b/lib/ar.js
@@ -40,7 +40,7 @@ Archive.prototype.append = function (fileBuffer, options) {
   }
 
   var header = buildHeader(name,
-    (stats.mtime.getTime()/1000) + "",
+    Math.floor(stats.mtime.getTime()/1000) + "",
     stats.uid + "",
     stats.gid + "",
     stats.mode.toString(8),


### PR DESCRIPTION
The timestamps in the ar archive have an invalid decimal format (due to the division by 1000).
It doesn't seem to really bother the debian  installer, but it causes problems with other tools (uploads to bintray's debian repository in my case).
